### PR TITLE
docs: add changelog entry for recap management

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 🕘 Changelog
 
+## v1.0.15 – October 2025
+- **Recap Management Launch** 📝
+  - Added dedicated admin Recap Management dashboard with create, edit, and delete flows
+  - Introduced recap form validation for title, date, location, sermon topic, and summary fields
+  - Implemented reusable recap data hook that centralizes Firestore CRUD with success/error messaging
+  - Updated admin and public recap pages to surface the new management experience
+
 ## v1.0.14 – September 2025
 - **Code Quality & Security** 🧹
   - Comprehensive ESLint cleanup (71 → 59 warnings, 17% improvement)


### PR DESCRIPTION
## Summary
- document the recap management dashboard launch and supporting hook
- highlight new validation requirements for recap fields
- note the admin dashboard updates that expose the feature

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6a72c41b08329ab212de2e1471b99